### PR TITLE
Add ConcurrentTest and ExecutorServiceUtils

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Warning: H2Util requires JPA, Spring and H2 dependencies which are defined as op
 ### TestClock
 TestClock is an implementation of the abstract class `Clock`, and provides features useful for testing. If not specified it is initialized with a fixed Instant in the past. Its time is fixed, this clock will not run. Therefore, it also provides features to manipulate its time.
 
+### ConcurrentTest
+ConcurrentTest offers support for tests which need to run on mutliple threads. It handles the overhead of submitting and evaluating each of a given number of a `task`. It uses the `ExecutorServiceUtils` to ensure that the `executorService` is properly shut down and the `task queue` is cleared, so that subsequent tests can run without interference.
+
 ## Usage
 Add the following Maven dependency to your project:
 

--- a/src/main/java/de/cronn/testutils/ConcurrentTest.java
+++ b/src/main/java/de/cronn/testutils/ConcurrentTest.java
@@ -1,0 +1,87 @@
+package de.cronn.testutils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+public class ConcurrentTest<T> {
+
+	private static final int TIMEOUT_MILLIS = 30_000;
+	private int concurrencyLevel = 10;
+	private final IndexedCallable<T> task;
+	private String threadNamePrefix = ConcurrentTest.class.getSimpleName();
+
+	public ConcurrentTest(IndexedCallable<T> task) {
+		this.task = task;
+	}
+
+	public static <T> ConcurrentTest<T> create(IndexedCallable<T> task) {
+		return new ConcurrentTest<>(task);
+	}
+
+	public ConcurrentTest<T> withConcurrencyLevel(int concurrencyLevel) {
+		this.concurrencyLevel = concurrencyLevel;
+		return this;
+	}
+
+	public ConcurrentTest<T> withThreadNamePrefix(String threadNamePrefix) {
+		this.threadNamePrefix = threadNamePrefix;
+		return this;
+	}
+
+	public ConcurrentTest<T> withThreadNamePrefixFromClass(Class<?> clazz) {
+		return withThreadNamePrefix(clazz.getSimpleName());
+	}
+
+	public void runAndAssertEachResult(Consumer<T> assertion) throws InterruptedException, ExecutionException {
+		ThreadFactory threadFactory = new NamedThreadFactory(threadNamePrefix);
+		ExecutorService executorService = Executors.newFixedThreadPool(concurrencyLevel, threadFactory);
+		try {
+			CompletionService<T> completionService = new ExecutorCompletionService<>(executorService);
+
+			for (int i = 0; i < concurrencyLevel; i++) {
+				completionService.submit(task.toCallable(i));
+			}
+
+			for (int i = 0; i < concurrencyLevel; i++) {
+				T result = completionService.take().get();
+				assertion.accept(result);
+			}
+		} finally {
+			ExecutorServiceUtils.shutdownOrThrow(executorService, threadNamePrefix, TIMEOUT_MILLIS);
+		}
+	}
+
+	private static class NamedThreadFactory implements ThreadFactory {
+		private final String prefix;
+
+		private final AtomicInteger threadCount = new AtomicInteger();
+
+		public NamedThreadFactory(String prefix) {
+			this.prefix = prefix;
+		}
+
+		@Override
+		public Thread newThread(Runnable r) {
+			return new Thread(r, prefix + threadCount.incrementAndGet());
+		}
+	}
+
+	@FunctionalInterface
+	public interface IndexedCallable<T> {
+
+		T call(int index) throws InterruptedException;
+
+		default Callable<T> toCallable(int index) {
+			return () -> call(index);
+		}
+
+
+	}
+}

--- a/src/main/java/de/cronn/testutils/ConcurrentTest.java
+++ b/src/main/java/de/cronn/testutils/ConcurrentTest.java
@@ -76,7 +76,7 @@ public class ConcurrentTest<T> {
 	@FunctionalInterface
 	public interface IndexedCallable<T> {
 
-		T call(int index) throws InterruptedException;
+		T call(int index) throws Exception;
 
 		default Callable<T> toCallable(int index) {
 			return () -> call(index);

--- a/src/main/java/de/cronn/testutils/ExecutorServiceUtils.java
+++ b/src/main/java/de/cronn/testutils/ExecutorServiceUtils.java
@@ -1,0 +1,77 @@
+package de.cronn.testutils;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ExecutorServiceUtils {
+
+	private static final Logger log = LoggerFactory.getLogger(ExecutorServiceUtils.class);
+
+	private ExecutorServiceUtils() {
+	}
+
+	public static void shutdownOrThrow(ExecutorService executor, String executorServiceName, long timeoutMs) {
+		if (executor != null) {
+			try {
+				if (!shutdownGracefully(executor, executorServiceName, timeoutMs)) {
+					boolean success = shutdownNow(executor, executorServiceName, timeoutMs);
+					Assertions.assertTrue(success, String.format("Failed to shutdown %s", executorServiceName));
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new TestUtilsRuntimeException("Failed to shutdown " + executorServiceName);
+			}
+		}
+	}
+
+	public static boolean shutdownNow(ExecutorService executorService, String executorServiceName, long timeoutMillis) throws InterruptedException {
+		return shutdown(executorService, executorServiceName, timeoutMillis, true);
+	}
+
+	public static boolean shutdownGracefully(ExecutorService executorService, String executorServiceName, long timeoutMillis) throws InterruptedException {
+		return shutdown(executorService, executorServiceName, timeoutMillis, false);
+	}
+
+	private static boolean shutdown(ExecutorService executorService, String executorServiceName, long timeoutMillis, boolean shutdownWithInterrupt) throws InterruptedException {
+		log.debug("Shutting down {}", executorServiceName);
+
+		if (shutdownWithInterrupt) {
+			executorService.shutdownNow();
+		} else {
+			executorService.shutdown();
+		}
+
+		clearQueue(executorService, executorServiceName);
+
+		boolean success = executorService.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS);
+		if (success) {
+			log.info("Finished shutdown of '{}'", executorServiceName);
+		} else {
+			if (executorService instanceof ThreadPoolExecutor) {
+				ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
+				log.warn("Shutdown of '{}' timed out after {} ms. Active tasks: {}", executorServiceName, timeoutMillis, threadPoolExecutor.getActiveCount());
+			} else {
+				log.warn("Shutdown of '{}' timed out after {} ms.", executorServiceName, timeoutMillis);
+			}
+		}
+		return success;
+	}
+
+	private static void clearQueue(ExecutorService executorService, String executorServiceName) {
+		if (executorService instanceof ThreadPoolExecutor) {
+			ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
+			BlockingQueue<Runnable> queue = threadPoolExecutor.getQueue();
+			if (!queue.isEmpty()) {
+				int queueSize = queue.size();
+				log.warn("Clearing approximately {} elements from queue of '{}'", queueSize, executorServiceName);
+				queue.clear();
+			}
+		}
+	}
+}

--- a/src/main/java/de/cronn/testutils/TestUtilsRuntimeException.java
+++ b/src/main/java/de/cronn/testutils/TestUtilsRuntimeException.java
@@ -1,0 +1,23 @@
+package de.cronn.testutils;
+
+public class TestUtilsRuntimeException extends RuntimeException {
+
+	public TestUtilsRuntimeException() {
+		super();
+	}
+
+	public TestUtilsRuntimeException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public TestUtilsRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	public TestUtilsRuntimeException(String message) {
+		super(message);
+	}
+
+	public TestUtilsRuntimeException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/test/java/de/cronn/testutils/ConcurrentTestTest.java
+++ b/src/test/java/de/cronn/testutils/ConcurrentTestTest.java
@@ -1,0 +1,55 @@
+package de.cronn.testutils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class ConcurrentTestTest {
+
+	@Test
+	@Timeout(30)
+	void shouldSubmitAndAssert() throws ExecutionException, InterruptedException {
+		AtomicInteger atomicInteger = new AtomicInteger(0);
+		Set<Integer> set = new HashSet<>();
+
+		ConcurrentTest.create(index -> atomicInteger.addAndGet(1))
+			.withThreadNamePrefixFromClass(ConcurrentTestTest.class)
+			.withConcurrencyLevel(100)
+			.runAndAssertEachResult(result -> {
+				assertThat(set).doesNotContain(result);
+				set.add(result);
+			});
+
+		assertThat(set).hasSize(100);
+		assertThat(atomicInteger.get()).isEqualTo(100);
+	}
+
+	@Test
+	@Timeout(30)
+	void shouldRunConcurrentThreads() throws ExecutionException, InterruptedException {
+		CyclicBarrier cyclicBarrier = new CyclicBarrier(100);
+		ConcurrentTest.create(index -> {
+				try {
+					cyclicBarrier.await(3000, TimeUnit.MILLISECONDS);
+					return true;
+				} catch (BrokenBarrierException | TimeoutException e) {
+					throw new RuntimeException(e);
+				}
+			})
+			.withThreadNamePrefixFromClass(ConcurrentTestTest.class)
+			.withConcurrencyLevel(100)
+			.runAndAssertEachResult(result -> assertThat(result).isTrue());
+		assertThat(cyclicBarrier.isBroken()).isFalse();
+		assertThat(cyclicBarrier.getNumberWaiting()).isZero();
+	}
+}

--- a/src/test/java/de/cronn/testutils/ExecutorServiceUtilsTest.java
+++ b/src/test/java/de/cronn/testutils/ExecutorServiceUtilsTest.java
@@ -1,0 +1,52 @@
+package de.cronn.testutils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+class ExecutorServiceUtilsTest {
+
+	@Test
+	@Timeout(30)
+	void shouldShutDownInfiniteLoopAndClearQueue() {
+		ExecutorService executorService = Executors.newFixedThreadPool(1);
+		try {
+			Callable<Void> task = () -> {
+				for (int i = 0; i < 30; i++) {
+					Thread.sleep(1000);
+				}
+				return null;
+			};
+			Future<Void> firstFuture = executorService.submit(task);
+			for (int i = 0; i < 10; i++) {
+				executorService.submit(task);
+			}
+			Future<Void> lastFuture = executorService.submit(task);
+
+			ExecutorServiceUtils.shutdownOrThrow(executorService, "TestExecutorService", 3000);
+
+			assertThat(firstFuture).isDone();
+			assertThat(lastFuture).isNotDone();
+			assertThat(((ThreadPoolExecutor) executorService).getQueue()).isEmpty();
+			assertThat(executorService.isShutdown()).isTrue();
+			assertThat(executorService.isTerminated()).isTrue();
+		} finally {
+			executorService.shutdown();
+			try {
+				if (!executorService.awaitTermination(1000, TimeUnit.MILLISECONDS)) {
+					executorService.shutdownNow();
+				}
+			} catch (InterruptedException e) {
+				executorService.shutdownNow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `ConcurrentTest` and `ExecutorServiceUtils` from Mustard test utils. Also adds Tests for both classes (not from mustard, created with help from @pfhartma).
