### PR TITLE
H2Util: Exclude PostgreSQL schema PG_CATALOG from being reset

### DIFF
--- a/spring-boot-tests/h2/src/main/java/de/cronn/testutils/h2/H2PostgresModeUtilTest.java
+++ b/spring-boot-tests/h2/src/main/java/de/cronn/testutils/h2/H2PostgresModeUtilTest.java
@@ -1,0 +1,9 @@
+package de.cronn.testutils.h2;
+
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {
+	"spring.datasource.url=jdbc:h2:mem:testdb;INIT=CREATE SCHEMA IF NOT EXISTS SECOND_SCHEMA;MODE=PostgreSQL",
+})
+public abstract class H2PostgresModeUtilTest extends H2UtilTest {
+}

--- a/spring-boot-tests/h2/src/main/java/de/cronn/testutils/h2/H2UtilTest.java
+++ b/spring-boot-tests/h2/src/main/java/de/cronn/testutils/h2/H2UtilTest.java
@@ -150,7 +150,7 @@ public class H2UtilTest {
 	}
 
 	int countTables() {
-		return jdbcTemplate.queryForObject("select count(*) from information_schema.tables where table_type in ('TABLE', 'BASE TABLE') and table_schema <> 'INFORMATION_SCHEMA'", Integer.class);
+		return jdbcTemplate.queryForObject("select count(*) from information_schema.tables where table_type in ('TABLE', 'BASE TABLE') and table_schema not in ('INFORMATION_SCHEMA', 'PG_CATALOG')", Integer.class);
 	}
 
 }

--- a/spring-boot-tests/h2/tests-h2-1.4.x/src/test/java/de/cronn/testutils/h2/v1_4/H2PostgresModeUtilTest.java
+++ b/spring-boot-tests/h2/tests-h2-1.4.x/src/test/java/de/cronn/testutils/h2/v1_4/H2PostgresModeUtilTest.java
@@ -1,0 +1,4 @@
+package de.cronn.testutils.h2.v1_4;
+
+public class H2PostgresModeUtilTest extends de.cronn.testutils.h2.H2PostgresModeUtilTest {
+}

--- a/spring-boot-tests/h2/tests-h2-2.0.x/src/test/java/de/cronn/testutils/h2/v2_0/H2PostgresModeUtilTest.java
+++ b/spring-boot-tests/h2/tests-h2-2.0.x/src/test/java/de/cronn/testutils/h2/v2_0/H2PostgresModeUtilTest.java
@@ -1,0 +1,4 @@
+package de.cronn.testutils.h2.v2_0;
+
+public class H2PostgresModeUtilTest extends de.cronn.testutils.h2.H2PostgresModeUtilTest {
+}

--- a/spring-boot-tests/h2/tests-h2-2.1.x/src/test/java/de/cronn/testutils/h2/v2_1/H2PostgresModeUtilTest.java
+++ b/spring-boot-tests/h2/tests-h2-2.1.x/src/test/java/de/cronn/testutils/h2/v2_1/H2PostgresModeUtilTest.java
@@ -1,0 +1,4 @@
+package de.cronn.testutils.h2.v2_1;
+
+public class H2PostgresModeUtilTest extends de.cronn.testutils.h2.H2PostgresModeUtilTest {
+}

--- a/src/main/java/de/cronn/testutils/h2/H2Util.java
+++ b/src/main/java/de/cronn/testutils/h2/H2Util.java
@@ -194,7 +194,7 @@ public class H2Util {
 		Set<Table> tableNames = new LinkedHashSet<>();
 		String selectAllTables = "SELECT * FROM INFORMATION_SCHEMA.TABLES " +
 			"WHERE TABLE_TYPE IN ('TABLE' /* h2 v1.4 */, 'BASE TABLE' /* h2 v2.x */) " +
-			"AND TABLE_SCHEMA <> 'INFORMATION_SCHEMA'";
+			"AND TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA', 'PG_CATALOG')";
 		try (PreparedStatement stmt = con.prepareStatement(selectAllTables); ResultSet tables = stmt.executeQuery()) {
 			while (tables.next()) {
 				String schema = tables.getString("TABLE_SCHEMA");


### PR DESCRIPTION
Starting from version [2.0.202](https://github.com/h2database/h2database/releases/tag/version-2.0.202) of [h2database](https://github.com/h2database/h2database), the _de.cronn.testutils.h2.H2Util#resetDatabase_ method has stopped working when running with **MODE=PostgreSQL**. It attempts to truncate tables in the PG_CATALOG schema which results in an exception, e.g: 

- java.lang.RuntimeException: org.h2.jdbc.JdbcSQLSyntaxErrorException: Cannot truncate "PG_CATALOG.PG_ATTRDEF"; SQL statement: TRUNCATE TABLE PG_CATALOG.PG_ATTRDEF RESTART IDENTITY [90106-206]

