### PR TITLE
Setup dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,20 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 25
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1


### PR DESCRIPTION
See https://github.com/gradle/actions/blob/main/dependency-submission/README.md

This automatically publishes the gradle dependencies to https://github.com/cronn/test-utils/network/dependencies 

GitHub automatically informs maintainers about security vulnerabilities for all detected dependencies.