### PR TITLE
Broaden buildAuthorizationMatrix parameter types to Collection<? extends Credentials>

### DIFF
--- a/spring-boot-tests/authorization-test/src/test/java/de/cronn/testutils/authorization/AuthorizationTestUtilTest.java
+++ b/spring-boot-tests/authorization-test/src/test/java/de/cronn/testutils/authorization/AuthorizationTestUtilTest.java
@@ -3,7 +3,10 @@ package de.cronn.testutils.authorization;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +102,7 @@ class AuthorizationTestUtilTest implements JUnit5ValidationFileAssertions {
 
 	@Test
 	void buildAuthorizationMatrix_throwsOnEmptyCredentials(AuthorizationTestUtil authorizationTestUtil) {
-		assertThatThrownBy(() -> authorizationTestUtil.buildAuthorizationMatrix(List.of()))
+		assertThatThrownBy(() -> authorizationTestUtil.buildAuthorizationMatrix(Set.of()))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("must not be empty");
 	}
@@ -112,7 +115,7 @@ class AuthorizationTestUtilTest implements JUnit5ValidationFileAssertions {
 
 		String accessToken1 = tokenFactory.tokenForRoles(userProofFactory.jwkThumbprint(), Role.USER);
 		String accessToken2 = tokenFactory.tokenForRoles(adminProofFactory.jwkThumbprint(), Role.ADMIN);
-		List<Credentials> credentials = List.of(
+		Collection<DPoPCredentials> credentials = List.of(
 			new DPoPCredentials(Role.ADMIN.name(), accessToken2, adminProofFactory),
 			new DPoPCredentials(Role.USER.name(), accessToken1, userProofFactory));
 		String accessToken = tokenFactory.tokenForRoles(noRoleProofFactory.jwkThumbprint());

--- a/src/authorizationTestSupport/java/de/cronn/testutils/authorization/AuthorizationTestUtil.java
+++ b/src/authorizationTestSupport/java/de/cronn/testutils/authorization/AuthorizationTestUtil.java
@@ -4,6 +4,7 @@ package de.cronn.testutils.authorization;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedHashSet;
@@ -93,23 +94,23 @@ public final class AuthorizationTestUtil {
 	}
 
 	/**
-	 * Like {@link #buildAuthorizationMatrix(List, List)} with no ignored path prefixes.
+	 * Like {@link #buildAuthorizationMatrix(Collection, List)} with no ignored path prefixes.
 	 */
-	public String buildAuthorizationMatrix(List<Credentials> credentials) {
+	public String buildAuthorizationMatrix(Collection<? extends Credentials> credentials) {
 		return buildAuthorizationMatrix(credentials, List.of());
 	}
 
 	/**
-	 * Like {@link #buildAuthorizationMatrix(List, Credentials, List)} without an authenticated credentials check.
+	 * Like {@link #buildAuthorizationMatrix(Collection, Credentials, List)} without an authenticated credentials check.
 	 */
-	public String buildAuthorizationMatrix(List<Credentials> credentials, List<String> ignoredPathPrefixes) {
+	public String buildAuthorizationMatrix(Collection<? extends Credentials> credentials, List<String> ignoredPathPrefixes) {
 		return buildAuthorizationMatrix(credentials, null, ignoredPathPrefixes);
 	}
 
 	/**
-	 * Like {@link #buildAuthorizationMatrix(List, Credentials, List)} with no ignored path prefixes.
+	 * Like {@link #buildAuthorizationMatrix(Collection, Credentials, List)} with no ignored path prefixes.
 	 */
-	public String buildAuthorizationMatrix(List<Credentials> credentials, @Nullable Credentials authenticatedCredentials) {
+	public String buildAuthorizationMatrix(Collection<? extends Credentials> credentials, @Nullable Credentials authenticatedCredentials) {
 		return buildAuthorizationMatrix(credentials, authenticatedCredentials, List.of());
 	}
 
@@ -127,7 +128,7 @@ public final class AuthorizationTestUtil {
 	 * @return a Markdown table with columns METHOD, PATH, ALLOWED_ROLES
 	 */
 	public String buildAuthorizationMatrix(
-		List<Credentials> credentials,
+		Collection<? extends Credentials> credentials,
 		@Nullable Credentials authenticatedCredentials,
 		List<String> ignoredPathPrefixes) {
 
@@ -178,7 +179,7 @@ public final class AuthorizationTestUtil {
 		return "http://localhost:" + localServerPort;
 	}
 
-	private static void validateCredentials(List<Credentials> credentials) {
+	private static void validateCredentials(Collection<? extends Credentials> credentials) {
 		if (credentials.isEmpty()) {
 			throw new IllegalArgumentException("credentials must not be empty");
 		}
@@ -247,7 +248,7 @@ public final class AuthorizationTestUtil {
 		RestClient restClient,
 		String baseUrl,
 		List<Endpoint> endpoints,
-		List<Credentials> credentials,
+		Collection<? extends Credentials> credentials,
 		@Nullable Credentials authenticatedCredentials) {
 
 		return endpoints.stream()
@@ -259,7 +260,7 @@ public final class AuthorizationTestUtil {
 		RestClient restClient,
 		String baseUrl,
 		Endpoint endpoint,
-		List<Credentials> credentials,
+		Collection<? extends Credentials> credentials,
 		@Nullable Credentials authenticatedCredentials) {
 
 		if (isUnauthenticatedAllowed(restClient, baseUrl, endpoint)) {
@@ -284,7 +285,7 @@ public final class AuthorizationTestUtil {
 		return isAllowed(callEndpoint(restClient, baseUrl, endpoint, authenticatedCredentials));
 	}
 
-	private static List<String> checkAccess(RestClient restClient, String baseUrl, Endpoint endpoint, List<Credentials> credentials) {
+	private static List<String> checkAccess(RestClient restClient, String baseUrl, Endpoint endpoint, Collection<? extends Credentials> credentials) {
 		return credentials.stream()
 			.filter(c -> isAllowed(callEndpoint(restClient, baseUrl, endpoint, c)))
 			.map(Credentials::name)
@@ -366,7 +367,7 @@ public final class AuthorizationTestUtil {
 		}
 	}
 
-	private static Set<String> allNames(List<Credentials> credentials) {
+	private static Set<String> allNames(Collection<? extends Credentials> credentials) {
 		return credentials.stream()
 			.map(Credentials::name)
 			.collect(Collectors.toCollection(LinkedHashSet::new));


### PR DESCRIPTION
Without the wildcard, callers could not pass e.g. a `List<BasicAuthCredentials>` or `List<DPoPCredentials>`, only a `List<Credentials>` would be accepted due to Java generics invariance.