### PR TITLE
Make captured query validation files OS-independent

### DIFF
--- a/src/jpaQueryCapturingSupport/java/de/cronn/testutils/jpa/query/FormattingQueryLogEntryCreator.java
+++ b/src/jpaQueryCapturingSupport/java/de/cronn/testutils/jpa/query/FormattingQueryLogEntryCreator.java
@@ -12,7 +12,7 @@ import net.ttddyy.dsproxy.proxy.ParameterSetOperation;
 
 public class FormattingQueryLogEntryCreator extends AbstractQueryLogEntryCreator {
 
-	private static final String LINE_SEPARATOR = System.lineSeparator();
+	private static final String LINE_SEPARATOR = "\n";
 
 	private final SqlQueryFormatter sqlQueryFormatter;
 


### PR DESCRIPTION
System.lineSeparator() made the committed validation files depend on the host OS, causing spurious diffs across platforms.

Hardcode "\n" for stable line endings everywhere.