### PR TITLE
Mark endpoints that are inaccessible by any role as forbidden

### DIFF
--- a/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withAllThreeRoles.md
+++ b/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withAllThreeRoles.md
@@ -25,7 +25,7 @@
 | GET     | /guest-only         | GUEST            |
 | DELETE  | /items/{id}         | ADMIN            |
 | GET     | /items/{id}         | ADMIN            |
-| GET     | /locked             |                  |
+| GET     | /locked             | {FORBIDDEN}      |
 | GET     | /not-found          | USER             |
 | GET     | /public             | {⚠ PERMIT_ALL ⚠} |
 | GET     | /server-error       | USER             |

--- a/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withCustomizedMarkdownTableRenderer.md
+++ b/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withCustomizedMarkdownTableRenderer.md
@@ -15,7 +15,7 @@
 | GET     | /guest-only    | GUEST           |
 | DELETE  | /items/{id}    | ADMIN           |
 | GET     | /items/{id}    | ADMIN           |
-| GET     | /locked        |                 |
+| GET     | /locked        | {FORBIDDEN}     |
 | GET     | /not-found     | USER            |
 | GET     | /public        | {PUBLIC}        |
 | GET     | /server-error  | USER            |

--- a/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withDPoPCredentials.md
+++ b/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withDPoPCredentials.md
@@ -12,10 +12,10 @@
 | GET     | /any-role      | {ANY_ROLE}       |
 | GET     | /authenticated | {AUTHENTICATED}  |
 | GET     | /gone          | USER             |
-| GET     | /guest-only    |                  |
+| GET     | /guest-only    | {FORBIDDEN}      |
 | DELETE  | /items/{id}    | ADMIN            |
 | GET     | /items/{id}    | ADMIN            |
-| GET     | /locked        |                  |
+| GET     | /locked        | {FORBIDDEN}      |
 | GET     | /not-found     | USER             |
 | GET     | /public        | {⚠ PERMIT_ALL ⚠} |
 | GET     | /server-error  | USER             |

--- a/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withIgnoredActuatorPrefix.md
+++ b/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withIgnoredActuatorPrefix.md
@@ -15,7 +15,7 @@
 | GET     | /guest-only    | GUEST            |
 | DELETE  | /items/{id}    | ADMIN            |
 | GET     | /items/{id}    | ADMIN            |
-| GET     | /locked        |                  |
+| GET     | /locked        | {FORBIDDEN}      |
 | GET     | /not-found     | USER             |
 | GET     | /public        | {⚠ PERMIT_ALL ⚠} |
 | GET     | /server-error  | USER             |

--- a/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withMixedCredentials.md
+++ b/spring-boot-tests/authorization-test/data/test/validation/AuthorizationTestUtilTest_buildAuthorizationMatrix_withMixedCredentials.md
@@ -15,7 +15,7 @@
 | GET     | /guest-only    | GUEST            |
 | DELETE  | /items/{id}    | ADMIN            |
 | GET     | /items/{id}    | ADMIN            |
-| GET     | /locked        |                  |
+| GET     | /locked        | {FORBIDDEN}      |
 | GET     | /not-found     | USER             |
 | GET     | /public        | {⚠ PERMIT_ALL ⚠} |
 | GET     | /server-error  | USER             |

--- a/src/authorizationTestSupport/java/de/cronn/testutils/authorization/MarkdownTableRenderer.java
+++ b/src/authorizationTestSupport/java/de/cronn/testutils/authorization/MarkdownTableRenderer.java
@@ -74,6 +74,8 @@ public class MarkdownTableRenderer implements ResultsRenderer {
 		Set<String> allowed = new LinkedHashSet<>(result.allowedRoles());
 		if (allowed.equals(allCredentialNames)) {
 			return "{ANY_ROLE}";
+		} else if (allowed.isEmpty()) {
+			return "{FORBIDDEN}";
 		} else {
 			return String.join("<br>", allowed);
 		}


### PR DESCRIPTION
This makes the impact of these endpoints more visible. An empty cell is ambiguous and does not accurately represent that the endpoint is impossible to access for any user.